### PR TITLE
add firmware to installation, and cleanup warnings

### DIFF
--- a/driver/linux/Makefile.in
+++ b/driver/linux/Makefile.in
@@ -10,6 +10,10 @@ INCLUDES += -I$(src)/../../include
 INCLUDES += -I$(src)/../../include/link
 INCLUDES += -I$(src)/../../include/flea
 
+FIRMWARE  = ../../firmware/fwbin/70015/bcm70015fw.bin
+FIRMWARE += ../../firmware/fwbin/70012/bcm70012fw.bin
+FIRMWARE += ../../firmware/fwbin/70012/bcmFilePlayFw.bin
+
 EXTRA_CFLAGS   = -D__KERNEL__ -DMODULE $(INCLUDES) $(INC)
 EXTRA_CFLAGS  += -Wall -Wstrict-prototypes -Wno-trigraphs -Werror -O2
 
@@ -38,6 +42,10 @@ install:
 		install -d /lib/modules/$(shell uname -r)/kernel/drivers/video/broadcom ; \
 		install -m 0644 crystalhd.ko /lib/modules/$(shell uname -r)/kernel/drivers/video/broadcom ; \
 	fi
+	if [ ! -d /lib/firmware ] ; \
+		then install -d /lib/firmware ; \
+	fi
+	install -t /lib/firmware $(FIRMWARE)
 	/sbin/depmod -a
 
 clean:

--- a/driver/linux/crystalhd_fleafuncs.c
+++ b/driver/linux/crystalhd_fleafuncs.c
@@ -593,6 +593,8 @@ void crystalhd_flea_runtime_power_dn(struct crystalhd_hw *hw)
 	hw->pfnWriteDevRegister(hw->adp,
 		BCHP_DECODE_CPUREGS2_0_REG_WATCHDOG_TMR,
 		0xffffffff);
+#else
+	regVal = 0;
 #endif
 
 	/* Stop memory arbiter first to freese memory access */

--- a/driver/linux/crystalhd_lnx.c
+++ b/driver/linux/crystalhd_lnx.c
@@ -498,7 +498,7 @@ fail:
 	return rc;
 }
 
-static void __exit chd_dec_release_chdev(struct crystalhd_adp *adp)
+static void chd_dec_release_chdev(struct crystalhd_adp *adp)
 {
 	crystalhd_ioctl_data *temp = NULL;
 	if (!adp)
@@ -570,7 +570,7 @@ static int __init chd_pci_reserve_mem(struct crystalhd_adp *pinfo)
 	return 0;
 }
 
-static void __exit chd_pci_release_mem(struct crystalhd_adp *pinfo)
+static void chd_pci_release_mem(struct crystalhd_adp *pinfo)
 {
 	if (!pinfo)
 		return;
@@ -800,7 +800,7 @@ static struct pci_device_id chd_dec_pci_id_table[] = {
 #endif
 MODULE_DEVICE_TABLE(pci, chd_dec_pci_id_table);
 
-static struct pci_driver bc_chd_driver = {
+static struct pci_driver bc_chd_driver __refdata = {
 	.name     = "crystalhd",
 	.probe    = chd_dec_pci_probe,
 	.remove   = __exit_p(chd_dec_pci_remove),


### PR DESCRIPTION
Thanks for your work updating the `crystalhd` driver for recent kernels.

Here are a couple of small patches.
