### PR TITLE
Linux 4.9+ compatibility

### DIFF
--- a/driver/linux/crystalhd_misc.c
+++ b/driver/linux/crystalhd_misc.c
@@ -653,7 +653,10 @@ BC_STATUS crystalhd_map_dio(struct crystalhd_adp *adp, void *ubuff,
 
 	down_read(&current->mm->mmap_sem);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0)
+	res = get_user_pages(uaddr, nr_pages, rw == READ ? FOLL_WRITE : 0,
+			     dio->pages, NULL);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
 	res = get_user_pages_remote(current, current->mm, uaddr, nr_pages, rw == READ,
 			     0, dio->pages, NULL);
 #else


### PR DESCRIPTION
I'm not convinced that get_user_pages_remote is the right thing to use, and get_user_pages() is usable in 4.9+.

Note that the 'rw == READ' thing is very suspicious. That was the 'write' flag but we check if our mode is READ. In the new API it's a flag so the weirdness is even more obvious.

You should validate this is the right behaviour before merging - although it's worked fine for me, looking like this.