### PR TITLE
DKMS: Support building for non-current kernel

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -7,7 +7,7 @@ BUILT_MODULE_LOCATION[0]=driver/linux
 DEST_MODULE_LOCATION[0]="/updates/dkms/"
 AUTOINSTALL=yes
 
-MAKE[0]="cd driver/linux && autoconf && ./configure && make"
+MAKE[0]="cd driver/linux && autoconf && ./configure --with-kernel-path=/lib/modules/$kernelver/build && make"
 CLEAN="make -C driver/linux clean distclean"
 
 POST_INSTALL="install_firmware_dkms.sh"


### PR DESCRIPTION
Today, a dkms build will silently build for the running kernel rather than the target kernel, and you only notice when the driver fails to load.