### PR TITLE
Linux 4.11 Compatibility: Fix incorrect version check

### DIFF
--- a/driver/linux/crystalhd_cmds.c
+++ b/driver/linux/crystalhd_cmds.c
@@ -25,7 +25,7 @@
  **********************************************************************/
 
 #include <linux/version.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0)
 #include <linux/sched/signal.h>
 #endif
 


### PR DESCRIPTION
I accidentally set one of them to check for 4.9.0, which breaks
compilation on 4.9 and 4.10.