### PR TITLE
crystalhd_misc: Fix 5.8 mmap_sem error

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,6 +23,8 @@ Here are the ones I've found, roughly in order of most obsolete/broken to newest
 
 5. [**@dbason**](http://github.com/dbason)'s tree, forked from Yeradis's tree, and last updated in 2016: https://github.com/dbason/crystalhd
 
+6. [**@linuxgorl**](http://github.com/linuxgorl)'s tree, forked from dbason's tree, compiles on >= Linux 5.10. https://github.com/linuxgorl/crystalhd
+
 **Only the last version can be built and used without error on a modern kernel.** ([**@dlenski**](http://github.com/dlenski) is using it with kernel 4.4.0 and BCM70015.)
 
 

--- a/driver/linux/crystalhd_misc.c
+++ b/driver/linux/crystalhd_misc.c
@@ -653,8 +653,11 @@ BC_STATUS crystalhd_map_dio(struct crystalhd_adp *adp, void *ubuff,
 			return BC_STS_INSUFF_RES;
 		}
 	}
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
+	mmap_read_lock(current->mm);
+#else
 	down_read(&current->mm->mmap_sem);
+#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0)
 	res = get_user_pages(uaddr, nr_pages, rw == READ ? FOLL_WRITE : 0,
@@ -667,8 +670,11 @@ BC_STATUS crystalhd_map_dio(struct crystalhd_adp *adp, void *ubuff,
 			     0, dio->pages, NULL);
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
+	mmap_read_unlock(current->mm);
+#else
 	up_read(&current->mm->mmap_sem);
-
+#endif
 	/* Save for release..*/
 	dio->sig = crystalhd_dio_locked;
 	if (res < nr_pages) {


### PR DESCRIPTION
Since Linux 5.8, mmap_sem has been renamed to mmap_lock according to [this patch](https://lkml.org/lkml/2020/6/4/180).
The kernel module builds without any error with this patch, I haven't tested it yet since my BCM70015 arrives in a month.